### PR TITLE
feat: add lambda functions and block access if not secret

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -32,3 +32,15 @@ variable "zone_id" {
   description = "ID of the Route 53 Hosted Zone in which to create an alias record"
   type        = string
 }
+
+variable "lambda_origin_request_arn" {
+  description = "Lambda edge function arn to bind to origin-request"
+  type        = string 
+  default     = ""
+}
+
+variable "lambda_origin_response_arn" {
+  description = "Lambda edge function arn to bind to origin-response"
+  type        = string 
+  default     = ""
+}


### PR DESCRIPTION
Add two variables for origin-request and origin-response lambda arns.
Add them to the default cloudfront distribution.
Add new restrictions on bucket to to deny anything that isn't the secret string coming from cloudfront to S3 bucket