### PR TITLE
fix: add dynamic block for lambda function

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -114,16 +114,20 @@ resource "aws_cloudfront_distribution" "cdn" {
 
     viewer_protocol_policy = "redirect-to-https"
 
-    lambda_function_association {
-      count = var.lambda_origin_request_arn ? 1 : 0
-      event_type = "origin-request"
-      lambda_arn = var.lambda_origin_request_arn
+    dynamic "lambda_function_association" {
+      for_each = var.lambda_origin_request_arn ? [{}] : []
+      content {
+        event_type = "origin-request"
+        lambda_arn = var.lambda_origin_request_arn
+      }
     }
 
-    lambda_function_association {
-      count = var.lambda_origin_response_arn ? 1 : 0
-      event_type = "origin-response"
-      lambda_arn = var.lambda_origin_response_arn
+    dynamic "lambda_function_association" {
+      for_each = var.lambda_origin_response_arn ? [{}] : []
+      content {
+        event_type = "origin-response"
+        lambda_arn = var.lambda_origin_response_arn
+      }
     }
 
   }

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     viewer_protocol_policy = "redirect-to-https"
 
     dynamic "lambda_function_association" {
-      for_each = var.lambda_origin_request_arn ? [{}] : []
+      for_each = var.lambda_origin_request_arn == "" ? [] : [{}]
       content {
         event_type = "origin-request"
         lambda_arn = var.lambda_origin_request_arn
@@ -123,7 +123,7 @@ resource "aws_cloudfront_distribution" "cdn" {
     }
 
     dynamic "lambda_function_association" {
-      for_each = var.lambda_origin_response_arn ? [{}] : []
+      for_each = var.lambda_origin_response_arn == "" ? [] : [{}]
       content {
         event_type = "origin-response"
         lambda_arn = var.lambda_origin_response_arn

--- a/variables.tf
+++ b/variables.tf
@@ -36,11 +36,11 @@ variable "zone_id" {
 variable "lambda_origin_request_arn" {
   description = "Lambda edge function arn to bind to origin-request"
   type        = string 
-  default     = ""
+  default     = null
 }
 
 variable "lambda_origin_response_arn" {
   description = "Lambda edge function arn to bind to origin-response"
   type        = string 
-  default     = ""
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -36,11 +36,11 @@ variable "zone_id" {
 variable "lambda_origin_request_arn" {
   description = "Lambda edge function arn to bind to origin-request"
   type        = string 
-  default     = null
+  default     = ""
 }
 
 variable "lambda_origin_response_arn" {
   description = "Lambda edge function arn to bind to origin-response"
   type        = string 
-  default     = null
+  default     = ""
 }


### PR DESCRIPTION
count did not work for conditional blocks, when I tested I guess i was on the wrong revision and my make plan worked. But after refreshing and pulling master again, it didn't work. We need to use dynamic blocks instead. Quick change to fix this issue.