### PR TITLE
feat: add arn output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,7 @@ output "cdn_domain_name" {
   description = "Domain name of the Cloudfront Distribution"
   value       = "${aws_cloudfront_distribution.cdn.domain_name}"
 }
+output "cdn_arn" {
+  description = "ARN of the Cloudfront Distribution"
+  value       = "${aws_cloudfront_distribution.cdn.arn}"
+}


### PR DESCRIPTION
Require arn of main cloudfront distribution for user permissions to allow the creation of a cache invalidation